### PR TITLE
Fix git argument handling and keep paging at the view-logs prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: 'main'
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,19 @@ jobs:
 
       - name: Create and push tag if manual trigger
         if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ github.event.inputs.tag }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a ${{ github.event.inputs.tag }} -m "Release ${{ github.event.inputs.tag }}"
-          git push origin ${{ github.event.inputs.tag }}
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
 
       - name: Checkout tag for goreleaser
         if: github.event_name == 'workflow_dispatch'
-        run: git checkout ${{ github.event.inputs.tag }}
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: git checkout "$TAG"
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.2.7 — 2026-07-15
+
+### Added
+- Page navigation (↑/↓/PgUp/PgDn) stays live while the "View detailed logs? (y/N)" prompt is shown; y/n/Enter/Esc answer the prompt. Falls back to the plain prompt on non-TTY output or piped stdin.
+- The hard-reset confirmation prompt now also warns about repos with unpushed commits (HEAD ahead of the target) and repos whose status check failed, not just dirty working trees.
+- Stale `gb-logs-*` temp directories older than 7 days are purged on startup; the current run's logs are kept.
+
+### Fixed
+- `gb -dv` and `gb -tr` now exit non-zero when any repo fails, matching every other operation.
+- Conflicting operation flags (e.g. `-rs` with `-rh`, `-c` with `-l`) are rejected instead of silently running only one.
+- `gb -dv` with a stray positional argument errors instead of silently ignoring it.
+- `-tr`/`--track` no longer consumes a following positional argument during flag reordering.
+- Ctrl+C now cancels in-flight git processes in switch/reset/rebase/diverge/track (previously they ran to completion).
+- Worktree removal no longer attempts to delete the workspace parent directories.
+- `.env` copied into a new worktree keeps the source file's permissions.
+- Installer scripts fail hard when the release checksum entry or sha256 tool is missing instead of skipping verification.
+
+### Security
+- Branch/ref/remote/pattern arguments starting with `-` are rejected, preventing option injection into git (e.g. `-rb=--exec=<cmd>`).
+- `fetch`/`ls-remote` run with `protocol.ext.allow=never`; `git status` preflight runs with `core.fsmonitor=false`, so a scanned repo's config can't execute commands through those paths.
+- Release workflow no longer interpolates the dispatch tag input directly into shell commands; CI workflow runs with read-only permissions.
+
 ## v0.2.6 — 2026-06-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Page navigation (↑/↓/PgUp/PgDn) stays live while the "View detailed logs? (y/N)" prompt is shown; y/n/Enter/Esc answer the prompt. Falls back to the plain prompt on non-TTY output or piped stdin.
-- The hard-reset confirmation prompt now also warns about repos with unpushed commits (HEAD ahead of the target) and repos whose status check failed, not just dirty working trees.
+- The hard-reset confirmation prompt now also warns about repos whose HEAD is ahead of the reset target (those commits would be discarded) and repos whose status check failed, not just dirty working trees.
 - Stale `gb-logs-*` temp directories older than 7 days are purged on startup; the current run's logs are kept.
 
 ### Fixed
@@ -12,7 +12,7 @@
 - Conflicting operation flags (e.g. `-rs` with `-rh`, `-c` with `-l`) are rejected instead of silently running only one.
 - `gb -dv` with a stray positional argument errors instead of silently ignoring it.
 - `-tr`/`--track` no longer consumes a following positional argument during flag reordering.
-- Ctrl+C now cancels in-flight git processes in switch/reset/rebase/diverge/track (previously they ran to completion).
+- In-flight git subprocesses now honor context cancellation (`exec.CommandContext`) in switch/reset/rebase/diverge/track, so a parent-driven cancel or SIGINT in non-interactive runs stops them promptly. While the interactive progress UI is active, Ctrl+C stops the display but the current git command still completes.
 - Worktree removal no longer attempts to delete the workspace parent directories.
 - `.env` copied into a new worktree keeps the source file's permissions.
 - Installer scripts fail hard when the release checksum entry or sha256 tool is missing instead of skipping verification.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ irm https://raw.githubusercontent.com/ntancardoso/gb/main/install.ps1 | iex
 
 Installs to `%LOCALAPPDATA%\Programs\gb` and adds it to your user PATH automatically.
 
+> Some antivirus products (e.g. Avast) hold or block freshly downloaded unsigned binaries. The install still succeeds; whitelist the install directory or retry `gb --version` after the scan completes.
+
 ### Uninstall
 
 **Linux / macOS:**
@@ -454,15 +456,6 @@ gb -c "status"
 - **Windows**: Full support including WSL symlinks and NTFS junctions
 - **Linux**: Native support with symlink resolution
 - **macOS**: Native support with symlink resolution
-
-## Contributing
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature-branch`)
-3. Run tests: `go test ./...`
-4. Commit your changes
-5. Push to the branch
-6. Create a Pull Request
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/ntancardoso/gb/main/install.sh | sh
 curl -fsSL https://raw.githubusercontent.com/ntancardoso/gb/main/install.sh | sh -s -- --pre-release
 
 # Specific version
-curl -fsSL https://raw.githubusercontent.com/ntancardoso/gb/main/install.sh | sh -s -- --version v0.2.3
+curl -fsSL https://raw.githubusercontent.com/ntancardoso/gb/main/install.sh | sh -s -- --version v0.2.7
 ```
 
 ### Windows (PowerShell)
@@ -42,7 +42,7 @@ irm https://raw.githubusercontent.com/ntancardoso/gb/main/install.ps1 | iex
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/ntancardoso/gb/main/install.ps1))) -PreRelease
 
 # Specific version
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/ntancardoso/gb/main/install.ps1))) -Version v0.2.3
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/ntancardoso/gb/main/install.ps1))) -Version v0.2.7
 ```
 
 Installs to `%LOCALAPPDATA%\Programs\gb` and adds it to your user PATH automatically.
@@ -432,7 +432,7 @@ gb -c "status"
 - **Sync: rebase conflict**: `git rebase --abort` is run automatically; repo is reported as failed with clean state restored
 - **Sync: non-interactive terminal**: `-rh` and `-rb` exit with an error if stdin is not a TTY; use `-rs` for CI pipelines
 - **Sync: mid-operation repo**: Repos in the middle of a merge, cherry-pick, or revert are skipped by hard reset to avoid silent data loss
-- **Sync: unpushed commits**: The hard-reset confirmation prompt also lists repos whose HEAD is ahead of the target, since those commits would be discarded
+- **Sync: commits ahead of target**: The hard-reset confirmation prompt also lists repos whose HEAD is ahead of the reset target, since those commits would be discarded
 - **Exit codes**: All operations (including `-dv` and `-tr`) exit non-zero when any repo fails
 
 ## Behavior Notes
@@ -445,7 +445,7 @@ gb -c "status"
 
 ## Requirements
 
-- **Git**: Must be installed and accessible in PATH
+- **Git 2.24+**: Must be installed and accessible in PATH (divergence checks use `--end-of-options`)
 - **Go 1.26+**: For building from source
 - **File System**: Read access to repository directories
 

--- a/README.md
+++ b/README.md
@@ -239,9 +239,11 @@ gb -wo feature/my-task               # Print worktree paths (for scripting)
 gb -l -iw                            # Include worktree repos in branch listing
 ```
 
-The `-i`/`-e` (include/exclude dirs) and `-ib`/`-eb` (include/exclude by current branch) filters all apply to worktree commands. By default, worktree repos are excluded from all operations. Use `-iw` / `--include-worktrees` to include them.
+The `-i`/`-e` (include/exclude dirs) and `-ib`/`-eb` (include/exclude by current branch) filters all apply to worktree commands. Worktree commands always operate on the main repo (linked worktrees are deduplicated). For all other operations, worktree repos are excluded by default; use `-iw` / `--include-worktrees` to include them.
 
 The `-wr` flag supports glob patterns (`*`, `?`, `[...]`) to match multiple branches at once. The main worktree is never removed.
+
+`-wc` copies the repo's `.env` file (if present) into the new worktree, preserving its permissions.
 
 ### Advanced Options
 
@@ -253,6 +255,8 @@ gb --workers 50 -c "status"    # Long form
 # Custom page size for progress display
 gb -ps 10 -c "status"          # Show 10 repos per page
 gb --size 30 -c "status"       # Show 30 repos per page
+# Pages can be switched with the arrow / PgUp / PgDn keys while the operation
+# runs and while the "View detailed logs? (y/N)" prompt is shown
 
 # Exclude additional directories
 gb -e "build,dist,temp" -c "status"           # Short form
@@ -428,11 +432,21 @@ gb -c "status"
 - **Sync: rebase conflict**: `git rebase --abort` is run automatically; repo is reported as failed with clean state restored
 - **Sync: non-interactive terminal**: `-rh` and `-rb` exit with an error if stdin is not a TTY; use `-rs` for CI pipelines
 - **Sync: mid-operation repo**: Repos in the middle of a merge, cherry-pick, or revert are skipped by hard reset to avoid silent data loss
+- **Sync: unpushed commits**: The hard-reset confirmation prompt also lists repos whose HEAD is ahead of the target, since those commits would be discarded
+- **Exit codes**: All operations (including `-dv` and `-tr`) exit non-zero when any repo fails
+
+## Behavior Notes
+
+- Shallow repos are fetched with `--depth=1` on switch/reset to keep them shallow
+- `-c`/`-sh` commands time out after 5 minutes and are retried up to 3 times on timeout
+- Fetch/ls-remote runs with `protocol.ext.allow=never`; a repo's git hooks and aliases still run as usual, so only scan directory trees you trust
+- Branch/ref/remote arguments must not start with `-`
+- Log directories (`gb-logs-*` in the system temp dir) from runs older than 7 days are purged automatically on the next run
 
 ## Requirements
 
 - **Git**: Must be installed and accessible in PATH
-- **Go 1.19+**: For building from source
+- **Go 1.26+**: For building from source
 - **File System**: Read access to repository directories
 
 ## Platform Support

--- a/install.ps1
+++ b/install.ps1
@@ -221,7 +221,12 @@ function Main {
     }
 
     Write-Host ""
-    & (Join-Path $installDir $Binary) --version
+    try {
+      & (Join-Path $installDir $Binary) --version
+    } catch {
+      Write-Warn "Installed, but running the binary failed (antivirus may be blocking or still scanning it)."
+      Write-Warn "Verify with 'gb --version' in a new terminal, or whitelist $installDir in your antivirus."
+    }
 
   } finally {
     Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/install.ps1
+++ b/install.ps1
@@ -91,8 +91,7 @@ function Confirm-Checksum {
   $lines = Get-Content $ChecksumsFile
   $entry = $lines | Where-Object { $_ -match "\s$([regex]::Escape($name))$" } | Select-Object -First 1
   if (-not $entry) {
-    Write-Warn "No checksum entry for $name, skipping verification"
-    return
+    Write-Fatal "No checksum entry for $name in checksums.txt - refusing to install unverified binary"
   }
   $expected = ($entry -split '\s+')[0]
   $actual   = Get-FileHash256 $Archive

--- a/install.sh
+++ b/install.sh
@@ -129,8 +129,7 @@ verify_checksum() {
 
   expected="$(grep " ${archive_name}$" "$checksums_file" | awk '{print $1}')"
   if [ -z "$expected" ]; then
-    warn "No checksum entry for ${archive_name}, skipping verification"
-    return
+    fatal "No checksum entry for ${archive_name} in checksums.txt — refusing to install unverified binary"
   fi
 
   if command -v sha256sum >/dev/null 2>&1; then
@@ -138,8 +137,7 @@ verify_checksum() {
   elif command -v shasum >/dev/null 2>&1; then
     actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
   else
-    warn "sha256sum/shasum not found, skipping checksum verification"
-    return
+    fatal "sha256sum/shasum not found — cannot verify download, refusing to install"
   fi
 
   if [ "$actual" != "$expected" ]; then

--- a/internal/core/branch.go
+++ b/internal/core/branch.go
@@ -250,7 +250,7 @@ func executeCommandInRepos(ctx context.Context, root, command string, workers in
 	}
 
 	progress := NewProgressState(repos, fmt.Sprintf("Executing 'git %s'", command), cfg.PageSize)
-	stop := progress.start()
+	progress.StartInput()
 
 	results := runPool(ctx, repos, workers, func(ctx context.Context, r RepoInfo) CommandResult {
 		progress.UpdateStatus(r.RelPath, statusProcessing, "")
@@ -278,15 +278,12 @@ func executeCommandInRepos(ctx context.Context, root, command string, workers in
 		}
 	}
 
-	stop()
-
-	fmt.Println("\n" + StyleBold.Render("--- Summary ---"))
-	fmt.Printf("Executed 'git %s' in %d repos: %s succeeded, %s failed\n",
+	summary := StyleBold.Render("--- Summary ---") + "\n" + fmt.Sprintf("Executed 'git %s' in %d repos: %s succeeded, %s failed",
 		command, success+failed,
 		StyleSuccess.Render(fmt.Sprintf("%d", success)),
 		StyleFailed.Render(fmt.Sprintf("%d", failed)))
 
-	if PromptViewLogs() {
+	if progress.FinishAndPromptViewLogs(summary) {
 		DisplayLogs(logManager, results)
 	} else {
 		fmt.Printf("\nLogs are available at: %s\n", logManager.GetTempDir())
@@ -318,7 +315,7 @@ func executeShellInRepos(ctx context.Context, root, command string, workers int,
 	}
 
 	progress := NewProgressState(repos, fmt.Sprintf("Executing '%s'", command), cfg.PageSize)
-	stop := progress.start()
+	progress.StartInput()
 
 	results := runPool(ctx, repos, workers, func(ctx context.Context, r RepoInfo) CommandResult {
 		progress.UpdateStatus(r.RelPath, statusProcessing, "")
@@ -355,15 +352,12 @@ func executeShellInRepos(ctx context.Context, root, command string, workers int,
 		}
 	}
 
-	stop()
-
-	fmt.Println("\n" + StyleBold.Render("--- Summary ---"))
-	fmt.Printf("Executed '%s' in %d repos: %s succeeded, %s failed\n",
+	summary := StyleBold.Render("--- Summary ---") + "\n" + fmt.Sprintf("Executed '%s' in %d repos: %s succeeded, %s failed",
 		command, success+failed,
 		StyleSuccess.Render(fmt.Sprintf("%d", success)),
 		StyleFailed.Render(fmt.Sprintf("%d", failed)))
 
-	if PromptViewLogs() {
+	if progress.FinishAndPromptViewLogs(summary) {
 		DisplayLogs(logManager, results)
 	} else {
 		fmt.Printf("\nLogs are available at: %s\n", logManager.GetTempDir())

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -160,11 +160,11 @@ func TestProcessSingleRepo(t *testing.T) {
 	createGitRepo(t, tmpDir)
 
 	repo := RepoInfo{Path: tmpDir, RelPath: "test"}
-	result := processSingleRepo(repo, "main", "origin", nil)
+	result := processSingleRepo(context.Background(), repo, "main", "origin", nil)
 	if result.Success {
 		branch, _ := getBranch(tmpDir)
 		if branch != "main" && branch != "master" {
-			result = processSingleRepo(repo, "master", "origin", nil)
+			result = processSingleRepo(context.Background(), repo, "master", "origin", nil)
 		}
 	}
 
@@ -172,7 +172,7 @@ func TestProcessSingleRepo(t *testing.T) {
 		t.Errorf("expected success, got error: %s", result.Error)
 	}
 
-	result = processSingleRepo(repo, "nonexistent", "origin", nil)
+	result = processSingleRepo(context.Background(), repo, "nonexistent", "origin", nil)
 	if result.Success {
 		t.Error("expected failure for non-existent branch")
 	}
@@ -785,7 +785,7 @@ func TestProcessSingleRepoSkipsLockedBranch(t *testing.T) {
 	runCmd(t, mainRepo, "git", "worktree", "add", wtPath, "locked-branch")
 
 	repo := RepoInfo{Path: mainRepo, RelPath: "repo"}
-	result := processSingleRepo(repo, "locked-branch", "origin", nil)
+	result := processSingleRepo(context.Background(), repo, "locked-branch", "origin", nil)
 
 	if !result.Skipped {
 		t.Error("expected result to be skipped when branch is locked in worktree")

--- a/internal/core/diverge.go
+++ b/internal/core/diverge.go
@@ -45,7 +45,7 @@ func getTrackingRef(dir string) (string, error) {
 	return ref, nil
 }
 
-func processSingleDiverge(repo RepoInfo, ref, defaultRemote string) DivergeResult {
+func processSingleDiverge(ctx context.Context, repo RepoInfo, ref, defaultRemote string) DivergeResult {
 	if !checkHasCommits(repo.Path) {
 		return DivergeResult{RelPath: repo.RelPath, Skipped: true, SkipReason: "no commits"}
 	}
@@ -67,13 +67,13 @@ func processSingleDiverge(repo RepoInfo, ref, defaultRemote string) DivergeResul
 		remoteRef = remote + "/" + resolvedBranch
 	}
 
-	verifyCmd := exec.Command("git", "rev-parse", "--verify", remoteRef)
+	verifyCmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", "--end-of-options", remoteRef)
 	verifyCmd.Dir = repo.Path
 	if verifyCmd.Run() != nil {
 		return DivergeResult{RelPath: repo.RelPath, Branch: branch, UpstreamRef: remoteRef, Skipped: true, SkipReason: "remote ref not found"}
 	}
 
-	cmd := exec.Command("git", "rev-list", "--left-right", "--count", "HEAD..."+remoteRef)
+	cmd := exec.CommandContext(ctx, "git", "rev-list", "--left-right", "--count", "HEAD..."+remoteRef)
 	cmd.Dir = repo.Path
 	out, err := cmd.Output()
 	if err != nil {
@@ -116,8 +116,8 @@ func checkDiverge(ctx context.Context, root, ref string, workers int, cfg *Confi
 		"Found %d repos (filtered from %d discovered), checking divergence vs %s with %d workers...",
 		len(repos), total, displayRef, min(workers, len(repos)))))
 
-	results := runPool(ctx, repos, workers, func(_ context.Context, r RepoInfo) DivergeResult {
-		return processSingleDiverge(r, ref, cfg.Remote)
+	results := runPool(ctx, repos, workers, func(ctx context.Context, r RepoInfo) DivergeResult {
+		return processSingleDiverge(ctx, r, ref, cfg.Remote)
 	})
 
 	sort.Slice(results, func(i, j int) bool { return results[i].RelPath < results[j].RelPath })
@@ -195,6 +195,9 @@ func checkDiverge(ctx context.Context, root, ref string, workers int, cfg *Confi
 		fmt.Printf("  %s skipped (%s)\n", StyleSkipped.Render(fmt.Sprintf("%d", skipped)), strings.Join(reasonParts, ", "))
 	}
 
+	if failed > 0 {
+		return errReposFailed
+	}
 	return nil
 }
 

--- a/internal/core/diverge_test.go
+++ b/internal/core/diverge_test.go
@@ -1,11 +1,14 @@
 package core
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestProcessSingleDivergeUpToDate(t *testing.T) {
 	repoDir, _ := makeRepoWithRemote(t)
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleDiverge(repo, "main", "origin")
+	res := processSingleDiverge(context.Background(), repo, "main", "origin")
 
 	if !res.Success {
 		t.Fatalf("expected success, got error: %s", res.Error)
@@ -36,7 +39,7 @@ func TestProcessSingleDivergeBehind(t *testing.T) {
 	runCmd(t, repoDir, "git", "fetch", "origin")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleDiverge(repo, "main", "origin")
+	res := processSingleDiverge(context.Background(), repo, "main", "origin")
 
 	if !res.Success {
 		t.Fatalf("expected success, got error: %s", res.Error)
@@ -54,7 +57,7 @@ func TestProcessSingleDivergeAhead(t *testing.T) {
 	runCmd(t, repoDir, "git", "commit", "-m", "local commit")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleDiverge(repo, "main", "origin")
+	res := processSingleDiverge(context.Background(), repo, "main", "origin")
 
 	if !res.Success {
 		t.Fatalf("expected success, got error: %s", res.Error)
@@ -85,7 +88,7 @@ func TestProcessSingleDivergeDiverged(t *testing.T) {
 	runCmd(t, repoDir, "git", "commit", "-m", "local commit")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleDiverge(repo, "main", "origin")
+	res := processSingleDiverge(context.Background(), repo, "main", "origin")
 
 	if !res.Success {
 		t.Fatalf("expected success, got error: %s", res.Error)
@@ -100,7 +103,7 @@ func TestProcessSingleDivergeTrackingBranch(t *testing.T) {
 	runCmd(t, repoDir, "git", "branch", "--set-upstream-to=origin/main", "main")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleDiverge(repo, "", "origin")
+	res := processSingleDiverge(context.Background(), repo, "", "origin")
 
 	if !res.Success {
 		t.Fatalf("expected success, got error=%q skipped=%v reason=%q", res.Error, res.Skipped, res.SkipReason)
@@ -117,7 +120,7 @@ func TestProcessSingleDivergeNoTracking(t *testing.T) {
 	repoDir, _ := makeRepoWithRemote(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleDiverge(repo, "", "origin")
+	res := processSingleDiverge(context.Background(), repo, "", "origin")
 
 	if res.Error != "" {
 		t.Fatalf("unexpected error: %s", res.Error)
@@ -132,7 +135,7 @@ func TestProcessSingleDivergeRemoteRefNotFound(t *testing.T) {
 	createGitRepo(t, repoDir)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleDiverge(repo, "main", "origin")
+	res := processSingleDiverge(context.Background(), repo, "main", "origin")
 
 	if res.Error != "" {
 		t.Fatalf("expected no error, got: %s", res.Error)

--- a/internal/core/e2e_test.go
+++ b/internal/core/e2e_test.go
@@ -42,7 +42,7 @@ func TestE2EHardResetFromDifferentBranchNotSkipped(t *testing.T) {
 	repoDir, _ := makeRepoOnFeatureBranchWithStaleOriginMain(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "hard", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "hard", nil)
 
 	if res.Skipped {
 		t.Fatalf("expected operation to run, but it was skipped: %q", res.SkipReason)
@@ -68,7 +68,7 @@ func TestE2ERebaseFromDifferentBranchNotSkipped(t *testing.T) {
 	repoDir, _ := makeRepoOnFeatureBranchWithStaleOriginMain(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "rebase", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "rebase", nil)
 
 	if res.Skipped {
 		t.Fatalf("expected rebase to run, but it was skipped: %q", res.SkipReason)
@@ -94,7 +94,7 @@ func TestE2ESoftResetFromDifferentBranchNotSkipped(t *testing.T) {
 	repoDir, _ := makeRepoOnFeatureBranchWithStaleOriginMain(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "soft", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "soft", nil)
 
 	if res.Skipped {
 		t.Fatalf("expected soft reset to run, but it was skipped: %q", res.SkipReason)
@@ -137,7 +137,7 @@ func TestE2ECustomRemoteProcessSingleReset(t *testing.T) {
 	repoDir, _ := makeRepoWithCustomRemote(t, "upstream")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	resOrigin := processSingleReset(repo, remoteTarget("origin", "main"), "soft", nil)
+	resOrigin := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "soft", nil)
 	if !resOrigin.Skipped {
 		t.Errorf("expected skip when using non-existent remote 'origin', got success=%v error=%q", resOrigin.Success, resOrigin.Error)
 	}
@@ -145,7 +145,7 @@ func TestE2ECustomRemoteProcessSingleReset(t *testing.T) {
 		t.Errorf("expected skip reason to mention 'origin', got %q", resOrigin.SkipReason)
 	}
 
-	resUpstream := processSingleReset(repo, remoteTarget("upstream", "main"), "soft", nil)
+	resUpstream := processSingleReset(context.Background(), repo, remoteTarget("upstream", "main"), "soft", nil)
 	if resUpstream.Skipped {
 		t.Fatalf("expected reset to run with remote 'upstream', got skipped: %q", resUpstream.SkipReason)
 	}
@@ -428,7 +428,7 @@ func TestE2EInlineRemoteReset(t *testing.T) {
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
 
 	target := resolveResetTarget(repoDir, "origin/main", "", "", false)
-	res := processSingleReset(repo, target, "hard", nil)
+	res := processSingleReset(context.Background(), repo, target, "hard", nil)
 	if !res.Success {
 		t.Fatalf("expected Success=true, got error=%q skipped=%v reason=%q", res.Error, res.Skipped, res.SkipReason)
 	}
@@ -455,7 +455,7 @@ func TestE2EInlineRemoteResetSlashedBranch(t *testing.T) {
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
 	target := resolveResetTarget(repoDir, "origin/feat/branch1", "", "", false)
-	res := processSingleReset(repo, target, "hard", nil)
+	res := processSingleReset(context.Background(), repo, target, "hard", nil)
 	if !res.Success {
 		t.Fatalf("expected Success=true resetting to origin/feat/branch1, got error=%q skipped=%v reason=%q",
 			res.Error, res.Skipped, res.SkipReason)
@@ -489,7 +489,7 @@ func TestE2ECustomRemoteSwitchBranch(t *testing.T) {
 	runCmd(t, otherDir, "git", "push", "upstream", "develop")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleRepo(repo, "develop", "upstream", nil)
+	res := processSingleRepo(context.Background(), repo, "develop", "upstream", nil)
 	if !res.Success {
 		t.Fatalf("expected switch to develop via upstream to succeed, got error: %q", res.Error)
 	}
@@ -552,7 +552,7 @@ func TestHardResetRunsWhenAlreadyAtTarget(t *testing.T) {
 	writeFile(t, repoDir, "README.md", "modified content — should be discarded")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "hard", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "hard", nil)
 
 	if res.Skipped {
 		t.Fatalf("hard reset must not be skipped even when HEAD == origin/main; got skipped: %q", res.SkipReason)
@@ -574,7 +574,7 @@ func TestRebaseRunsWhenAlreadyAtTarget(t *testing.T) {
 	repoDir, _ := makeRepoWithRemote(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "rebase", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "rebase", nil)
 
 	if res.Skipped {
 		t.Fatalf("rebase must not be skipped even when HEAD == origin/main; got skipped: %q", res.SkipReason)

--- a/internal/core/fixes_test.go
+++ b/internal/core/fixes_test.go
@@ -1,0 +1,148 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunConflictingModes(t *testing.T) {
+	err := Run(context.Background(), []string{"-rs", "main", "-rh", "main"})
+	if err == nil || !strings.Contains(err.Error(), "conflicting options") {
+		t.Fatalf("expected conflicting-options error, got: %v", err)
+	}
+	err = Run(context.Background(), []string{"-c", "status", "-l"})
+	if err == nil || !strings.Contains(err.Error(), "conflicting options") {
+		t.Fatalf("expected conflicting-options error, got: %v", err)
+	}
+}
+
+func TestRunRejectsLeadingDashRefs(t *testing.T) {
+	cases := [][]string{
+		{"-rb=--exec=echo pwned"},
+		{"-rs=--hard"},
+		{"-wr=-rf"},
+		{"-r=--upload-pack=echo", "-rs", "main"},
+	}
+	for _, args := range cases {
+		if err := Run(context.Background(), args); err == nil || !strings.Contains(err.Error(), "must not start with '-'") {
+			t.Errorf("args %v: expected leading-dash rejection, got: %v", args, err)
+		}
+	}
+}
+
+func TestRunDivergeRejectsLeftoverPositional(t *testing.T) {
+	err := Run(context.Background(), []string{"-dv", "origin", "main"})
+	if err == nil || !strings.Contains(err.Error(), "unexpected argument") {
+		t.Fatalf("expected unexpected-argument error, got: %v", err)
+	}
+}
+
+func TestReorderArgsTrackIsBool(t *testing.T) {
+	got := reorderArgs([]string{"-tr", "somebranch"})
+	want := []string{"-tr", "somebranch"}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestPreflightScanUnpushedCommits(t *testing.T) {
+	repoDir, _ := makeRepoAheadOfOrigin(t)
+	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
+	plan := classifyReset("origin/main", "", "origin", false)
+
+	dirty := preflightScan(context.Background(), []RepoInfo{repo}, 1, plan, "hard")
+	if len(dirty) != 1 || !strings.Contains(dirty[0].DirtyStatus, "1 unpushed commit(s)") {
+		t.Fatalf("expected unpushed-commit warning, got: %+v", dirty)
+	}
+
+	if dirty := preflightScan(context.Background(), []RepoInfo{repo}, 1, plan, "rebase"); len(dirty) != 0 {
+		t.Fatalf("rebase preflight must not warn about unpushed commits, got: %+v", dirty)
+	}
+}
+
+func TestPreflightScanStatusFailure(t *testing.T) {
+	notARepo := t.TempDir()
+	repo := RepoInfo{Path: notARepo, RelPath: "broken"}
+	plan := classifyReset("main", "", "origin", false)
+
+	dirty := preflightScan(context.Background(), []RepoInfo{repo}, 1, plan, "hard")
+	if len(dirty) != 1 || !strings.Contains(dirty[0].DirtyStatus, "status check failed") {
+		t.Fatalf("expected status-check-failed warning, got: %+v", dirty)
+	}
+}
+
+func TestCheckTrackFailedExitCode(t *testing.T) {
+	root := t.TempDir()
+	broken := filepath.Join(root, "broken")
+	if err := os.MkdirAll(filepath.Join(broken, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cfg := mustConfig(t, defaultExcludeDirs, nil, nil, nil, 20, false, "origin")
+	err := checkTrack(context.Background(), root, 2, cfg)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	_, _ = io.ReadAll(r)
+
+	if !errors.Is(err, errReposFailed) {
+		t.Fatalf("expected errReposFailed for broken repo, got: %v", err)
+	}
+}
+
+func TestCopyFilePreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.env")
+	dst := filepath.Join(dir, "dst.env")
+	if err := os.WriteFile(src, []byte("SECRET=1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	srcInfo, _ := os.Stat(src)
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dstInfo.Mode().Perm() != srcInfo.Mode().Perm() {
+		t.Fatalf("expected dst mode %v to match src mode %v", dstInfo.Mode().Perm(), srcInfo.Mode().Perm())
+	}
+}
+
+func TestPurgeStaleLogDirs(t *testing.T) {
+	stale := filepath.Join(os.TempDir(), "gb-logs-stale-test-fixture")
+	if err := os.MkdirAll(stale, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stale) })
+	old := time.Now().Add(-8 * 24 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	lm, err := NewLogManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lm.Cleanup() })
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatal("expected stale gb-logs dir to be purged")
+	}
+	if _, err := os.Stat(lm.GetTempDir()); err != nil {
+		t.Fatal("current-run log dir must survive the purge")
+	}
+}

--- a/internal/core/fixes_test.go
+++ b/internal/core/fixes_test.go
@@ -43,6 +43,24 @@ func TestRunDivergeRejectsLeftoverPositional(t *testing.T) {
 	}
 }
 
+func TestRunRejectsLeadingDashPositional(t *testing.T) {
+	// `--` terminates flag parsing, so a dashed positional would otherwise reach
+	// git as an option (e.g. `git switch --detach`).
+	err := Run(context.Background(), []string{"--", "--detach"})
+	if err == nil || !strings.Contains(err.Error(), "must not start with '-'") {
+		t.Fatalf("expected leading-dash rejection for positional, got: %v", err)
+	}
+}
+
+func TestRunRejectsStrayPositionalForBoolModes(t *testing.T) {
+	for _, flag := range []string{"-l", "-tr", "-wl"} {
+		err := Run(context.Background(), []string{flag, "main"})
+		if err == nil || !strings.Contains(err.Error(), "unexpected argument") {
+			t.Errorf("%s: expected unexpected-argument error, got: %v", flag, err)
+		}
+	}
+}
+
 func TestReorderArgsTrackIsBool(t *testing.T) {
 	got := reorderArgs([]string{"-tr", "somebranch"})
 	want := []string{"-tr", "somebranch"}
@@ -57,12 +75,12 @@ func TestPreflightScanUnpushedCommits(t *testing.T) {
 	plan := classifyReset("origin/main", "", "origin", false)
 
 	dirty := preflightScan(context.Background(), []RepoInfo{repo}, 1, plan, "hard")
-	if len(dirty) != 1 || !strings.Contains(dirty[0].DirtyStatus, "1 unpushed commit(s)") {
-		t.Fatalf("expected unpushed-commit warning, got: %+v", dirty)
+	if len(dirty) != 1 || !strings.Contains(dirty[0].DirtyStatus, "1 commit(s) ahead of target") {
+		t.Fatalf("expected commits-ahead warning, got: %+v", dirty)
 	}
 
 	if dirty := preflightScan(context.Background(), []RepoInfo{repo}, 1, plan, "rebase"); len(dirty) != 0 {
-		t.Fatalf("rebase preflight must not warn about unpushed commits, got: %+v", dirty)
+		t.Fatalf("rebase preflight must not warn about commits ahead of target, got: %+v", dirty)
 	}
 }
 

--- a/internal/core/logmanager.go
+++ b/internal/core/logmanager.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 type LogManager struct {
@@ -14,7 +15,30 @@ type LogManager struct {
 	mu       sync.Mutex
 }
 
+// purgeStaleLogDirs removes gb-logs-* temp dirs from previous runs older than
+// seven days. Best-effort: current-run logs are kept so the printed path stays
+// reviewable after gb exits.
+func purgeStaleLogDirs() {
+	entries, err := os.ReadDir(os.TempDir())
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-7 * 24 * time.Hour)
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), "gb-logs-") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(os.TempDir(), e.Name()))
+	}
+}
+
 func NewLogManager() (*LogManager, error) {
+	purgeStaleLogDirs()
+
 	tempDir, err := os.MkdirTemp("", "gb-logs-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)

--- a/internal/core/progress.go
+++ b/internal/core/progress.go
@@ -334,16 +334,6 @@ func (ps *ProgressState) StartInput() {
 	})
 }
 
-func (ps *ProgressState) StopInput() {
-	ps.stopOnce.Do(func() {
-		ps.stopped.Store(true)
-		if ps.program != nil {
-			ps.program.Send(doneMsg{})
-		}
-		ps.wg.Wait()
-	})
-}
-
 func (ps *ProgressState) UpdateStatus(relPath, status, errorMsg string) {
 	if ps.stopped.Load() {
 		return
@@ -358,7 +348,7 @@ func (ps *ProgressState) UpdateStatus(relPath, status, errorMsg string) {
 // FinishAndPromptViewLogs stops progress, shows the summary, and asks whether
 // to view detailed logs. In TUI mode the prompt runs inside the still-running
 // bubbletea program so the paging keys stay live; otherwise it falls back to a
-// plain summary print plus PromptViewLogs. Shares stopOnce with StopInput.
+// plain summary print plus PromptViewLogs. Runs once, guarded by stopOnce.
 func (ps *ProgressState) FinishAndPromptViewLogs(summary string) bool {
 	viewLogs, ran := false, false
 	ps.stopOnce.Do(func() {

--- a/internal/core/progress.go
+++ b/internal/core/progress.go
@@ -23,6 +23,7 @@ const (
 
 type statusMsg struct{ relPath, state, message string }
 type doneMsg struct{}
+type promptMsg struct{ summary string }
 type tickMsg time.Time
 
 type repoStatus struct {
@@ -42,6 +43,10 @@ type model struct {
 	startTime time.Time
 	done      bool
 	opName    string
+	prompting bool
+	answered  bool
+	viewLogs  bool
+	summary   string
 }
 
 func newModel(repos []RepoInfo, opName string, pageSize int) model {
@@ -90,17 +95,38 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.done = true
 		return m, tea.Quit
 
+	case promptMsg:
+		m.done = true
+		m.prompting = true
+		m.summary = msg.summary
+		return m, nil
+
 	case tea.KeyMsg:
-		switch msg.String() {
+		key := msg.String()
+		switch key {
 		case "up", "pgup":
 			if m.page > 0 {
 				m.page--
 			}
+			return m, nil
 		case "down", "pgdown":
 			if m.page < m.totalPages()-1 {
 				m.page++
 			}
-		case "ctrl+c":
+			return m, nil
+		}
+		if m.prompting {
+			switch key {
+			case "y", "Y":
+				m.answered, m.viewLogs = true, true
+				return m, tea.Quit
+			case "n", "N", "enter", "esc", "ctrl+c":
+				m.answered, m.viewLogs = true, false
+				return m, tea.Quit
+			}
+			return m, nil
+		}
+		if key == "ctrl+c" {
 			return m, tea.Quit
 		}
 		return m, nil
@@ -111,6 +137,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case spinner.TickMsg:
+		if m.done {
+			return m, nil
+		}
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
 		return m, cmd
@@ -121,6 +150,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case tickMsg:
+		if m.done {
+			return m, nil
+		}
 		return m, tickEvery()
 	}
 
@@ -157,6 +189,20 @@ func (m model) View() string {
 
 	if m.totalPages() > 1 {
 		fmt.Fprintf(&sb, "\n  Page %d/%d  ↑↓ PgUp/PgDn\n", m.page+1, m.totalPages())
+	}
+
+	if m.prompting {
+		sb.WriteString("\n" + m.summary + "\n\n")
+		prompt := "View detailed logs? (y/N)"
+		switch {
+		case m.answered && m.viewLogs:
+			prompt += ": y"
+		case m.answered:
+			prompt += ": n"
+		case m.totalPages() > 1:
+			prompt += "  " + StyleDim.Render("↑↓ PgUp/PgDn to page")
+		}
+		sb.WriteString(prompt + "\n")
 	}
 
 	return sb.String()
@@ -247,6 +293,8 @@ type ProgressState struct {
 	stopped      atomic.Bool
 	wg           sync.WaitGroup
 	stopOnce     sync.Once
+	finalModel   tea.Model // written only by the StartInput goroutine; read after wg.Wait
+	runErr       error
 }
 
 func NewProgressState(repos []RepoInfo, operationName string, pageSize int) *ProgressState {
@@ -278,7 +326,9 @@ func (ps *ProgressState) StartInput() {
 		return
 	}
 	ps.wg.Go(func() {
-		if _, err := ps.program.Run(); err != nil {
+		m, err := ps.program.Run()
+		ps.finalModel, ps.runErr = m, err
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "TUI error: %v\n", err)
 		}
 	})
@@ -305,9 +355,40 @@ func (ps *ProgressState) UpdateStatus(relPath, status, errorMsg string) {
 	fmt.Printf("%s: %s\n", relPath, status)
 }
 
-func (ps *ProgressState) start() func() {
-	ps.StartInput()
-	return ps.StopInput
+// FinishAndPromptViewLogs stops progress, shows the summary, and asks whether
+// to view detailed logs. In TUI mode the prompt runs inside the still-running
+// bubbletea program so the paging keys stay live; otherwise it falls back to a
+// plain summary print plus PromptViewLogs. Shares stopOnce with StopInput.
+func (ps *ProgressState) FinishAndPromptViewLogs(summary string) bool {
+	viewLogs, ran := false, false
+	ps.stopOnce.Do(func() {
+		ran = true
+		ps.stopped.Store(true)
+		if ps.program == nil || !stdinIsCharDevice() {
+			if ps.program != nil {
+				ps.program.Send(doneMsg{})
+			}
+			ps.wg.Wait()
+			fmt.Println("\n" + summary)
+			viewLogs = PromptViewLogs()
+			return
+		}
+		ps.program.Send(promptMsg{summary: summary})
+		ps.wg.Wait()
+		if m, ok := ps.finalModel.(model); ok && ps.runErr == nil && m.prompting {
+			viewLogs = m.viewLogs
+			return
+		}
+		// TUI exited before the prompt rendered (ctrl+c mid-run, Run error,
+		// external SIGINT): recover exactly as the non-TUI path does.
+		fmt.Println("\n" + summary)
+		viewLogs = PromptViewLogs()
+	})
+	if !ran {
+		fmt.Println("\n" + summary)
+		return PromptViewLogs()
+	}
+	return viewLogs
 }
 
 func progressStatusFromErr(err error) (string, string) {

--- a/internal/core/progress.go
+++ b/internal/core/progress.go
@@ -199,8 +199,6 @@ func (m model) View() string {
 			prompt += ": y"
 		case m.answered:
 			prompt += ": n"
-		case m.totalPages() > 1:
-			prompt += "  " + StyleDim.Render("↑↓ PgUp/PgDn to page")
 		}
 		sb.WriteString(prompt + "\n")
 	}

--- a/internal/core/progress_test.go
+++ b/internal/core/progress_test.go
@@ -1,0 +1,175 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func makeTestRepos(n int) []RepoInfo {
+	repos := make([]RepoInfo, n)
+	for i := range n {
+		repos[i] = RepoInfo{RelPath: fmt.Sprintf("repo-%02d", i)}
+	}
+	return repos
+}
+
+func keyMsg(s string) tea.KeyMsg {
+	switch s {
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "pgup":
+		return tea.KeyMsg{Type: tea.KeyPgUp}
+	case "pgdown":
+		return tea.KeyMsg{Type: tea.KeyPgDown}
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+c":
+		return tea.KeyMsg{Type: tea.KeyCtrlC}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+func isQuit(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	_, ok := cmd().(tea.QuitMsg)
+	return ok
+}
+
+func TestModelPromptMsgTransition(t *testing.T) {
+	m := newModel(makeTestRepos(3), "op", 10)
+	updated, cmd := m.Update(promptMsg{summary: "S"})
+	m = updated.(model)
+	if !m.done || !m.prompting || m.summary != "S" {
+		t.Fatalf("expected done+prompting with summary, got %+v", m)
+	}
+	if isQuit(cmd) {
+		t.Fatal("promptMsg must not quit the program")
+	}
+}
+
+func TestModelPagingWhilePrompting(t *testing.T) {
+	m := newModel(makeTestRepos(25), "op", 10)
+	updated, _ := m.Update(promptMsg{summary: "S"})
+	m = updated.(model)
+
+	steps := []struct {
+		key  string
+		page int
+	}{
+		{"down", 1}, {"pgdown", 2}, {"down", 2},
+		{"up", 1}, {"pgup", 0}, {"up", 0},
+	}
+	for _, s := range steps {
+		updated, cmd := m.Update(keyMsg(s.key))
+		m = updated.(model)
+		if m.page != s.page {
+			t.Fatalf("after %q expected page %d, got %d", s.key, s.page, m.page)
+		}
+		if isQuit(cmd) {
+			t.Fatalf("paging key %q must not quit while prompting", s.key)
+		}
+	}
+}
+
+func TestModelPromptAnswers(t *testing.T) {
+	cases := []struct {
+		key      string
+		viewLogs bool
+	}{
+		{"y", true}, {"Y", true},
+		{"n", false}, {"N", false},
+		{"enter", false}, {"esc", false}, {"ctrl+c", false},
+	}
+	for _, c := range cases {
+		m := newModel(makeTestRepos(3), "op", 10)
+		updated, _ := m.Update(promptMsg{summary: "S"})
+		m = updated.(model)
+		updated, cmd := m.Update(keyMsg(c.key))
+		m = updated.(model)
+		if !m.answered || m.viewLogs != c.viewLogs {
+			t.Errorf("key %q: expected answered with viewLogs=%v, got answered=%v viewLogs=%v",
+				c.key, c.viewLogs, m.answered, m.viewLogs)
+		}
+		if !isQuit(cmd) {
+			t.Errorf("key %q must quit the prompt", c.key)
+		}
+	}
+}
+
+func TestModelPromptIgnoresOtherKeys(t *testing.T) {
+	m := newModel(makeTestRepos(3), "op", 10)
+	updated, _ := m.Update(promptMsg{summary: "S"})
+	m = updated.(model)
+	for _, key := range []string{"a", "q", " "} {
+		updated, cmd := m.Update(keyMsg(key))
+		m = updated.(model)
+		if m.answered || isQuit(cmd) {
+			t.Errorf("key %q must be ignored while prompting", key)
+		}
+	}
+}
+
+func TestModelCtrlCBeforePrompt(t *testing.T) {
+	m := newModel(makeTestRepos(3), "op", 10)
+	updated, cmd := m.Update(keyMsg("ctrl+c"))
+	m = updated.(model)
+	if !isQuit(cmd) {
+		t.Fatal("ctrl+c must quit while running")
+	}
+	if m.answered || m.prompting {
+		t.Fatal("ctrl+c before prompt must not mark an answer")
+	}
+}
+
+func TestModelViewPrompting(t *testing.T) {
+	m := newModel(makeTestRepos(3), "op", 10)
+	if strings.Contains(m.View(), "View detailed logs?") {
+		t.Fatal("prompt must not render before promptMsg")
+	}
+
+	updated, _ := m.Update(promptMsg{summary: "SUMMARY-TEXT"})
+	m = updated.(model)
+	view := m.View()
+	if !strings.Contains(view, "SUMMARY-TEXT") || !strings.Contains(view, "View detailed logs? (y/N)") {
+		t.Fatalf("expected summary and prompt in view, got:\n%s", view)
+	}
+	if strings.Contains(view, "to page") {
+		t.Fatal("single page must not show the paging hint")
+	}
+
+	multi := newModel(makeTestRepos(25), "op", 10)
+	updated, _ = multi.Update(promptMsg{summary: "S"})
+	multi = updated.(model)
+	if !strings.Contains(multi.View(), "to page") {
+		t.Fatal("multi-page prompt must show the paging hint")
+	}
+
+	updated, _ = m.Update(keyMsg("y"))
+	m = updated.(model)
+	if !strings.Contains(m.View(), ": y") {
+		t.Fatal("answered view must echo the answer")
+	}
+}
+
+func TestModelTicksIdleWhenDone(t *testing.T) {
+	m := newModel(makeTestRepos(3), "op", 10)
+	updated, _ := m.Update(promptMsg{summary: "S"})
+	m = updated.(model)
+	if _, cmd := m.Update(tickMsg{}); cmd != nil {
+		t.Fatal("tickMsg must be idle after done")
+	}
+	if _, cmd := m.Update(spinner.TickMsg{}); cmd != nil {
+		t.Fatal("spinner tick must be idle after done")
+	}
+}

--- a/internal/core/progress_test.go
+++ b/internal/core/progress_test.go
@@ -145,14 +145,14 @@ func TestModelViewPrompting(t *testing.T) {
 		t.Fatalf("expected summary and prompt in view, got:\n%s", view)
 	}
 	if strings.Contains(view, "to page") {
-		t.Fatal("single page must not show the paging hint")
+		t.Fatal("prompt must not show the paging hint")
 	}
 
 	multi := newModel(makeTestRepos(25), "op", 10)
 	updated, _ = multi.Update(promptMsg{summary: "S"})
 	multi = updated.(model)
-	if !strings.Contains(multi.View(), "to page") {
-		t.Fatal("multi-page prompt must show the paging hint")
+	if strings.Contains(multi.View(), "to page") {
+		t.Fatal("multi-page prompt must not show the paging hint")
 	}
 
 	updated, _ = m.Update(keyMsg("y"))

--- a/internal/core/prompt.go
+++ b/internal/core/prompt.go
@@ -7,13 +7,16 @@ import (
 	"strings"
 )
 
-func PromptViewLogs() bool {
+func stdinIsCharDevice() bool {
 	fileInfo, err := os.Stdin.Stat()
 	if err != nil {
 		return false
 	}
+	return fileInfo.Mode()&os.ModeCharDevice != 0
+}
 
-	if (fileInfo.Mode() & os.ModeCharDevice) == 0 {
+func PromptViewLogs() bool {
+	if !stdinIsCharDevice() {
 		return false
 	}
 

--- a/internal/core/reset.go
+++ b/internal/core/reset.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -40,7 +41,7 @@ func syncBranch(ctx context.Context, root, branch, posBranch, mode string, worke
 			return fmt.Errorf("stdin is not a terminal; destructive operations require interactive confirmation — use -rs for non-interactive use")
 		}
 
-		dirtyRepos := preflightScan(ctx, repos, workers)
+		dirtyRepos := preflightScan(ctx, repos, workers, plan, mode)
 		if !PromptConfirmDestructive(operationDescription(mode, displayRef), len(repos), dirtyRepos) {
 			fmt.Println("Aborted.")
 			return nil
@@ -57,14 +58,14 @@ func syncBranch(ctx context.Context, root, branch, posBranch, mode string, worke
 	}
 
 	progress := NewProgressState(repos, opDesc, cfg.PageSize)
-	stop := progress.start()
+	progress.StartInput()
 
-	results := runPool(ctx, repos, workers, func(_ context.Context, r RepoInfo) ResetResult {
+	results := runPool(ctx, repos, workers, func(ctx context.Context, r RepoInfo) ResetResult {
 		progress.UpdateStatus(r.RelPath, statusProcessing, "")
 
 		logFile, _ := logManager.CreateLogFile(r.RelPath)
 		target := finalizeResetTarget(plan, r.Path)
-		res := processSingleReset(r, target, mode, logFile)
+		res := processSingleReset(ctx, r, target, mode, logFile)
 		if logFile != nil {
 			_ = logFile.Close()
 		}
@@ -94,12 +95,11 @@ func syncBranch(ctx context.Context, root, branch, posBranch, mode string, worke
 		}
 	}
 
-	stop()
-
-	fmt.Println("\n" + StyleBold.Render("--- Summary ---"))
-	fmt.Printf("Ran '%s' across %d repos:\n", opDesc, len(repos))
-	fmt.Printf("  %s succeeded\n", StyleSuccess.Render(fmt.Sprintf("%d", succeeded)))
-	fmt.Printf("  %s failed\n", StyleFailed.Render(fmt.Sprintf("%d", failed)))
+	var sum strings.Builder
+	sum.WriteString(StyleBold.Render("--- Summary ---") + "\n")
+	fmt.Fprintf(&sum, "Ran '%s' across %d repos:\n", opDesc, len(repos))
+	fmt.Fprintf(&sum, "  %s succeeded\n", StyleSuccess.Render(fmt.Sprintf("%d", succeeded)))
+	fmt.Fprintf(&sum, "  %s failed", StyleFailed.Render(fmt.Sprintf("%d", failed)))
 	if skipped > 0 {
 		reasons := make([]string, 0, len(skipReasons))
 		for reason := range skipReasons {
@@ -110,10 +110,10 @@ func syncBranch(ctx context.Context, root, branch, posBranch, mode string, worke
 		for _, reason := range reasons {
 			parts = append(parts, fmt.Sprintf("%s: %d", reason, skipReasons[reason]))
 		}
-		fmt.Printf("  %s skipped (%s)\n", StyleSkipped.Render(fmt.Sprintf("%d", skipped)), strings.Join(parts, ", "))
+		fmt.Fprintf(&sum, "\n  %s skipped (%s)", StyleSkipped.Render(fmt.Sprintf("%d", skipped)), strings.Join(parts, ", "))
 	}
 
-	if PromptViewLogs() {
+	if progress.FinishAndPromptViewLogs(sum.String()) {
 		DisplayResetLogs(logManager, results)
 	} else {
 		fmt.Printf("\nLogs are available at: %s\n", logManager.GetTempDir())
@@ -138,9 +138,24 @@ func operationDescription(mode, ref string) string {
 	return "unknown operation"
 }
 
-func preflightScan(ctx context.Context, repos []RepoInfo, workers int) []repoPreflightInfo {
-	results := runPool(ctx, repos, workers, func(_ context.Context, r RepoInfo) repoPreflightInfo {
-		return repoPreflightInfo{RelPath: r.RelPath, Path: r.Path, DirtyStatus: getDirtyStatus(r.Path)}
+func preflightScan(ctx context.Context, repos []RepoInfo, workers int, plan resetPlan, mode string) []repoPreflightInfo {
+	results := runPool(ctx, repos, workers, func(ctx context.Context, r RepoInfo) repoPreflightInfo {
+		status, err := getDirtyStatus(ctx, r.Path)
+		if err != nil {
+			status = "status check failed"
+		}
+		if mode == "hard" {
+			target := finalizeResetTarget(plan, r.Path)
+			if n := countUnpushedCommits(ctx, r.Path, target.ref()); n > 0 {
+				unpushed := fmt.Sprintf("%d unpushed commit(s)", n)
+				if status == "" {
+					status = unpushed
+				} else {
+					status += ", " + unpushed
+				}
+			}
+		}
+		return repoPreflightInfo{RelPath: r.RelPath, Path: r.Path, DirtyStatus: status}
 	})
 
 	dirty := make([]repoPreflightInfo, 0, len(results))
@@ -153,16 +168,31 @@ func preflightScan(ctx context.Context, repos []RepoInfo, workers int) []repoPre
 	return dirty
 }
 
-func getDirtyStatus(dir string) string {
-	cmd := exec.Command("git", "status", "--porcelain")
+// countUnpushedCommits counts commits on HEAD that the reset target lacks, i.e.
+// what a hard reset would discard beyond working-tree changes. Best-effort: an
+// unresolvable target (missing branch, no remote-tracking ref yet) counts as 0;
+// the actual reset handles those cases itself.
+func countUnpushedCommits(ctx context.Context, dir, ref string) int {
+	cmd := exec.CommandContext(ctx, "git", "rev-list", "--count", ref+"..HEAD")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
-		return ""
+		return 0
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(string(out)))
+	return n
+}
+
+func getDirtyStatus(ctx context.Context, dir string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-c", "core.fsmonitor=false", "status", "--porcelain")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
 	}
 	trimmed := strings.TrimSpace(string(out))
 	if trimmed == "" {
-		return ""
+		return "", nil
 	}
 
 	hasStaged, hasUnstaged := false, false
@@ -180,13 +210,13 @@ func getDirtyStatus(dir string) string {
 
 	switch {
 	case hasStaged && hasUnstaged:
-		return "staged + unstaged changes"
+		return "staged + unstaged changes", nil
 	case hasStaged:
-		return "staged changes"
+		return "staged changes", nil
 	case hasUnstaged:
-		return "unstaged changes"
+		return "unstaged changes", nil
 	}
-	return "changes"
+	return "changes", nil
 }
 
 // resetTarget is the resolved destination of a reset/rebase in a single repo.
@@ -274,7 +304,7 @@ func splitRemoteBranch(dir, arg string) (remote, branch string, ok bool) {
 	return "", "", false
 }
 
-func processSingleReset(repo RepoInfo, target resetTarget, mode string, logFile *os.File) ResetResult {
+func processSingleReset(ctx context.Context, repo RepoInfo, target resetTarget, mode string, logFile *os.File) ResetResult {
 	log := func(format string, args ...any) {
 		if logFile != nil {
 			_, _ = fmt.Fprintf(logFile, format+"\n", args...)
@@ -294,7 +324,7 @@ func processSingleReset(repo RepoInfo, target resetTarget, mode string, logFile 
 	}
 
 	if !target.isRemote {
-		effective, res, done := resolveLocalTarget(repo, target, log)
+		effective, res, done := resolveLocalTarget(ctx, repo, target, log)
 		if done {
 			return res
 		}
@@ -310,7 +340,7 @@ func processSingleReset(repo RepoInfo, target resetTarget, mode string, logFile 
 				return ResetResult{RelPath: repo.RelPath, Skipped: true, SkipReason: "no " + target.remote + " remote"}
 			}
 
-			found, netErr := checkBranchOnRemote(repo.Path, target.branch, target.remote)
+			found, netErr := checkBranchOnRemote(ctx, repo.Path, target.branch, target.remote)
 			if netErr != nil {
 				log("Error checking remote branch: %v", netErr)
 				return ResetResult{RelPath: repo.RelPath, Success: false, Error: fmt.Sprintf("network error: %v", netErr)}
@@ -322,7 +352,7 @@ func processSingleReset(repo RepoInfo, target resetTarget, mode string, logFile 
 		}
 
 		log("Fetching to update %s ref", target.ref())
-		if fetchErr := fetchBranchFromRemote(repo.Path, target.branch, target.remote, logFile); fetchErr != nil {
+		if fetchErr := fetchBranchFromRemote(ctx, repo.Path, target.branch, target.remote, logFile); fetchErr != nil {
 			log("Fetch failed: %v", fetchErr)
 			return ResetResult{RelPath: repo.RelPath, Success: false, Error: "fetch failed"}
 		}
@@ -335,11 +365,11 @@ func processSingleReset(repo RepoInfo, target resetTarget, mode string, logFile 
 
 	switch mode {
 	case "hard":
-		return doHardReset(repo, target, logFile, log)
+		return doHardReset(ctx, repo, target, logFile, log)
 	case "soft":
-		return doSoftReset(repo, target, logFile, log)
+		return doSoftReset(ctx, repo, target, logFile, log)
 	case "rebase":
-		return doRebase(repo, target, logFile, log)
+		return doRebase(ctx, repo, target, logFile, log)
 	}
 	return ResetResult{RelPath: repo.RelPath, Success: false, Error: "unknown mode"}
 }
@@ -348,14 +378,14 @@ func processSingleReset(repo RepoInfo, target resetTarget, mode string, logFile 
 // local branch exists it stays local; otherwise it falls back to the default
 // remote when the branch is present there. Returns done=true with a skip result
 // when the branch exists neither locally nor on the remote.
-func resolveLocalTarget(repo RepoInfo, target resetTarget, log func(string, ...any)) (resetTarget, ResetResult, bool) {
+func resolveLocalTarget(ctx context.Context, repo RepoInfo, target resetTarget, log func(string, ...any)) (resetTarget, ResetResult, bool) {
 	if checkLocalBranchExists(repo.Path, target.branch) {
 		return target, ResetResult{}, false
 	}
 
 	remote := target.fallbackRemote
 	if remote != "" && checkRemoteExists(repo.Path, remote) {
-		found, netErr := checkBranchOnRemote(repo.Path, target.branch, remote)
+		found, netErr := checkBranchOnRemote(ctx, repo.Path, target.branch, remote)
 		if netErr != nil {
 			log("Error checking remote branch: %v", netErr)
 			return target, ResetResult{RelPath: repo.RelPath, Success: false, Error: fmt.Sprintf("network error: %v", netErr)}, true
@@ -376,14 +406,14 @@ func checkLocalBranchExists(dir, branch string) bool {
 	return cmd.Run() == nil
 }
 
-func doHardReset(repo RepoInfo, target resetTarget, logFile *os.File, log func(string, ...any)) ResetResult {
+func doHardReset(ctx context.Context, repo RepoInfo, target resetTarget, logFile *os.File, log func(string, ...any)) ResetResult {
 	if inProgress, opName := checkMidOperation(repo.Path); inProgress {
 		log("Skipping: mid-%s operation in progress", opName)
 		return ResetResult{RelPath: repo.RelPath, Skipped: true, SkipReason: fmt.Sprintf("mid-%s in progress", opName)}
 	}
 
 	log("Executing: git reset --hard %s", target.ref())
-	cmd := exec.Command("git", "reset", "--hard", target.ref())
+	cmd := exec.CommandContext(ctx, "git", "reset", "--hard", target.ref())
 	cmd.Dir = repo.Path
 	if logFile != nil {
 		cmd.Stdout = logFile
@@ -397,7 +427,7 @@ func doHardReset(repo RepoInfo, target resetTarget, logFile *os.File, log func(s
 	return ResetResult{RelPath: repo.RelPath, Success: true}
 }
 
-func doSoftReset(repo RepoInfo, target resetTarget, logFile *os.File, log func(string, ...any)) ResetResult {
+func doSoftReset(ctx context.Context, repo RepoInfo, target resetTarget, logFile *os.File, log func(string, ...any)) ResetResult {
 	warning := ""
 	stagedCheck := exec.Command("git", "diff", "--cached", "--quiet")
 	stagedCheck.Dir = repo.Path
@@ -407,7 +437,7 @@ func doSoftReset(repo RepoInfo, target resetTarget, logFile *os.File, log func(s
 	}
 
 	log("Executing: git reset --soft %s", target.ref())
-	cmd := exec.Command("git", "reset", "--soft", target.ref())
+	cmd := exec.CommandContext(ctx, "git", "reset", "--soft", target.ref())
 	cmd.Dir = repo.Path
 	if logFile != nil {
 		cmd.Stdout = logFile
@@ -421,19 +451,24 @@ func doSoftReset(repo RepoInfo, target resetTarget, logFile *os.File, log func(s
 	return ResetResult{RelPath: repo.RelPath, Success: true, Warning: warning}
 }
 
-func doRebase(repo RepoInfo, target resetTarget, logFile *os.File, log func(string, ...any)) ResetResult {
+func doRebase(ctx context.Context, repo RepoInfo, target resetTarget, logFile *os.File, log func(string, ...any)) ResetResult {
 	if checkRebaseInProgress(repo.Path) {
 		log("Skipping: rebase already in progress")
 		return ResetResult{RelPath: repo.RelPath, Skipped: true, SkipReason: "rebase already in progress"}
 	}
 
-	if status := getDirtyStatus(repo.Path); status != "" {
+	status, statusErr := getDirtyStatus(ctx, repo.Path)
+	if statusErr != nil {
+		log("Failed: could not check working tree status: %v", statusErr)
+		return ResetResult{RelPath: repo.RelPath, Success: false, Error: "status check failed"}
+	}
+	if status != "" {
 		log("Failed: working tree must be clean for rebase (%s)", status)
 		return ResetResult{RelPath: repo.RelPath, Success: false, Error: "working tree must be clean"}
 	}
 
 	log("Executing: git rebase %s", target.ref())
-	cmd := exec.Command("git", "rebase", target.ref())
+	cmd := exec.CommandContext(ctx, "git", "rebase", target.ref())
 	cmd.Dir = repo.Path
 	if logFile != nil {
 		cmd.Stdout = logFile
@@ -480,8 +515,8 @@ func checkDetachedHEAD(dir string) bool {
 	return strings.TrimSpace(string(out)) == ""
 }
 
-func checkBranchOnRemote(dir, branch, remote string) (bool, error) {
-	cmd := exec.Command("git", "ls-remote", "--exit-code", "--heads", remote, branch)
+func checkBranchOnRemote(ctx context.Context, dir, branch, remote string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-c", "protocol.ext.allow=never", "ls-remote", "--exit-code", "--heads", remote, branch)
 	cmd.Dir = dir
 	err := cmd.Run()
 	if err == nil {
@@ -550,19 +585,19 @@ func checkAlreadyAtTarget(dir, ref string) bool {
 	return strings.TrimSpace(string(headOut)) == strings.TrimSpace(string(targetOut))
 }
 
-func fetchBranchFromRemote(dir, branch, remote string, logFile *os.File) error {
+func fetchBranchFromRemote(ctx context.Context, dir, branch, remote string, logFile *os.File) error {
 	checkCmd := exec.Command("git", "rev-parse", "--is-shallow-repository")
 	checkCmd.Dir = dir
 	shallowOut, shallowErr := checkCmd.Output()
 	isShallow := shallowErr == nil && strings.TrimSpace(string(shallowOut)) == "true"
 
-	args := []string{"fetch", remote}
+	args := []string{"-c", "protocol.ext.allow=never", "fetch", remote}
 	if isShallow {
 		args = append(args, "--depth=1")
 	}
 	args = append(args, branch)
 
-	fetchCmd := exec.Command("git", args...)
+	fetchCmd := exec.CommandContext(ctx, "git", args...)
 	fetchCmd.Dir = dir
 	if logFile != nil {
 		fetchCmd.Stdout = logFile

--- a/internal/core/reset.go
+++ b/internal/core/reset.go
@@ -146,12 +146,12 @@ func preflightScan(ctx context.Context, repos []RepoInfo, workers int, plan rese
 		}
 		if mode == "hard" {
 			target := finalizeResetTarget(plan, r.Path)
-			if n := countUnpushedCommits(ctx, r.Path, target.ref()); n > 0 {
-				unpushed := fmt.Sprintf("%d unpushed commit(s)", n)
+			if n := countCommitsAheadOfTarget(ctx, r.Path, target.ref()); n > 0 {
+				ahead := fmt.Sprintf("%d commit(s) ahead of target", n)
 				if status == "" {
-					status = unpushed
+					status = ahead
 				} else {
-					status += ", " + unpushed
+					status += ", " + ahead
 				}
 			}
 		}
@@ -168,11 +168,12 @@ func preflightScan(ctx context.Context, repos []RepoInfo, workers int, plan rese
 	return dirty
 }
 
-// countUnpushedCommits counts commits on HEAD that the reset target lacks, i.e.
-// what a hard reset would discard beyond working-tree changes. Best-effort: an
-// unresolvable target (missing branch, no remote-tracking ref yet) counts as 0;
-// the actual reset handles those cases itself.
-func countUnpushedCommits(ctx context.Context, dir, ref string) int {
+// countCommitsAheadOfTarget counts commits on HEAD that the reset target lacks,
+// i.e. what a hard reset would discard beyond working-tree changes. These may or
+// may not be pushed elsewhere; the point is they leave this branch's HEAD.
+// Best-effort: an unresolvable target (missing branch, no remote-tracking ref
+// yet) counts as 0; the actual reset handles those cases itself.
+func countCommitsAheadOfTarget(ctx context.Context, dir, ref string) int {
 	cmd := exec.CommandContext(ctx, "git", "rev-list", "--count", ref+"..HEAD")
 	cmd.Dir = dir
 	out, err := cmd.Output()

--- a/internal/core/reset_test.go
+++ b/internal/core/reset_test.go
@@ -172,7 +172,7 @@ func TestCheckBranchOnRemote(t *testing.T) {
 	repoDir, _ := makeRepoWithRemote(t)
 
 	t.Run("existing branch", func(t *testing.T) {
-		found, err := checkBranchOnRemote(repoDir, "main", "origin")
+		found, err := checkBranchOnRemote(context.Background(), repoDir, "main", "origin")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -182,7 +182,7 @@ func TestCheckBranchOnRemote(t *testing.T) {
 	})
 
 	t.Run("non-existent branch", func(t *testing.T) {
-		found, err := checkBranchOnRemote(repoDir, "does-not-exist-xyz", "origin")
+		found, err := checkBranchOnRemote(context.Background(), repoDir, "does-not-exist-xyz", "origin")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -306,7 +306,7 @@ func TestGetDirtyStatus(t *testing.T) {
 	t.Run("clean", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		createGitRepo(t, tmpDir)
-		if status := getDirtyStatus(tmpDir); status != "" {
+		if status, _ := getDirtyStatus(context.Background(), tmpDir); status != "" {
 			t.Errorf("expected clean, got %q", status)
 		}
 	})
@@ -315,7 +315,7 @@ func TestGetDirtyStatus(t *testing.T) {
 		tmpDir := t.TempDir()
 		createGitRepo(t, tmpDir)
 		writeFile(t, tmpDir, "untracked.txt", "new content")
-		if status := getDirtyStatus(tmpDir); status != "unstaged changes" {
+		if status, _ := getDirtyStatus(context.Background(), tmpDir); status != "unstaged changes" {
 			t.Errorf("expected 'unstaged changes', got %q", status)
 		}
 	})
@@ -325,7 +325,7 @@ func TestGetDirtyStatus(t *testing.T) {
 		createGitRepo(t, tmpDir)
 		writeFile(t, tmpDir, "staged.txt", "staged content")
 		runCmd(t, tmpDir, "git", "add", "staged.txt")
-		if status := getDirtyStatus(tmpDir); status != "staged changes" {
+		if status, _ := getDirtyStatus(context.Background(), tmpDir); status != "staged changes" {
 			t.Errorf("expected 'staged changes', got %q", status)
 		}
 	})
@@ -336,7 +336,7 @@ func TestGetDirtyStatus(t *testing.T) {
 		writeFile(t, tmpDir, "staged.txt", "staged content")
 		runCmd(t, tmpDir, "git", "add", "staged.txt")
 		writeFile(t, tmpDir, "untracked.txt", "untracked content")
-		if status := getDirtyStatus(tmpDir); status != "staged + unstaged changes" {
+		if status, _ := getDirtyStatus(context.Background(), tmpDir); status != "staged + unstaged changes" {
 			t.Errorf("expected 'staged + unstaged changes', got %q", status)
 		}
 	})
@@ -347,7 +347,7 @@ func TestProcessSingleResetSkipNoOrigin(t *testing.T) {
 	createGitRepo(t, tmpDir)
 
 	repo := RepoInfo{Path: tmpDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "soft", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "soft", nil)
 
 	if !res.Skipped {
 		t.Error("expected Skipped=true for no origin")
@@ -368,7 +368,7 @@ func TestProcessSingleResetSkipNoCommits(t *testing.T) {
 	runCmd(t, tmpDir, "git", "remote", "add", "origin", remoteDir)
 
 	repo := RepoInfo{Path: tmpDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "soft", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "soft", nil)
 
 	if !res.Skipped {
 		t.Error("expected Skipped=true for no commits")
@@ -385,7 +385,7 @@ func TestProcessSingleResetSkipDetachedHEAD(t *testing.T) {
 	runCmd(t, repoDir, "git", "checkout", hash)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "soft", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "soft", nil)
 
 	if !res.Skipped {
 		t.Error("expected Skipped=true for detached HEAD")
@@ -399,7 +399,7 @@ func TestProcessSingleResetSkipBranchNotOnOrigin(t *testing.T) {
 	repoDir, _ := makeRepoAheadOfOrigin(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "no-such-branch-xyz"), "soft", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "no-such-branch-xyz"), "soft", nil)
 
 	if !res.Skipped {
 		t.Error("expected Skipped=true for branch not on origin")
@@ -413,7 +413,7 @@ func TestProcessSingleResetSkipAlreadyAtTarget(t *testing.T) {
 	repoDir, _ := makeRepoWithRemote(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "soft", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "soft", nil)
 
 	if !res.Skipped {
 		t.Error("expected Skipped=true for already up to date")
@@ -427,7 +427,7 @@ func TestProcessSingleResetSoftMovesHEAD(t *testing.T) {
 	repoDir, _ := makeRepoAheadOfOrigin(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "soft", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "soft", nil)
 
 	if !res.Success {
 		t.Fatalf("expected Success=true, got error: %q", res.Error)
@@ -450,7 +450,7 @@ func TestProcessSingleResetSoftWarnsStagedChanges(t *testing.T) {
 	runCmd(t, repoDir, "git", "add", "extra.txt")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "soft", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "soft", nil)
 
 	if !res.Success {
 		t.Fatalf("expected Success=true, got error: %q", res.Error)
@@ -464,7 +464,7 @@ func TestProcessSingleResetHardDiscardsChanges(t *testing.T) {
 	repoDir, _ := makeRepoAheadOfOrigin(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "hard", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "hard", nil)
 
 	if !res.Success {
 		t.Fatalf("expected Success=true, got error: %q", res.Error)
@@ -488,7 +488,7 @@ func TestProcessSingleResetHardSkipsMidMerge(t *testing.T) {
 	}
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "hard", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "hard", nil)
 
 	if !res.Skipped {
 		t.Error("expected Skipped=true for mid-merge repo")
@@ -502,7 +502,7 @@ func TestProcessSingleResetRebaseHappyPath(t *testing.T) {
 	repoDir, _ := makeRepoAheadOfOrigin(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "rebase", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "rebase", nil)
 
 	if !res.Success {
 		t.Fatalf("expected Success=true, got error: %q", res.Error)
@@ -519,7 +519,7 @@ func TestProcessSingleResetRebaseFailsDirtyTree(t *testing.T) {
 	writeFile(t, repoDir, "dirty.txt", "dirty")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "rebase", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "rebase", nil)
 
 	if res.Success || res.Skipped {
 		t.Error("expected failure for dirty working tree during rebase")
@@ -538,7 +538,7 @@ func TestProcessSingleResetRebaseSkipsIfInProgress(t *testing.T) {
 	}
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "rebase", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "rebase", nil)
 
 	if !res.Skipped {
 		t.Error("expected Skipped=true for rebase already in progress")
@@ -566,7 +566,7 @@ func TestProcessSingleResetStaysOnCurrentBranch(t *testing.T) {
 	runCmd(t, repoDir, "git", "checkout", "-b", "feat/my-task")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "hard", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "hard", nil)
 
 	if !res.Success {
 		t.Fatalf("expected Success=true, got error: %q (skipped=%v reason=%q)", res.Error, res.Skipped, res.SkipReason)
@@ -589,7 +589,7 @@ func TestProcessSingleResetRebaseConflict(t *testing.T) {
 	repoDir, _ := makeRepoWithConflict(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "rebase", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "rebase", nil)
 
 	if res.Success || res.Skipped {
 		t.Errorf("expected failure for rebase conflict, got success=%v skipped=%v", res.Success, res.Skipped)
@@ -625,7 +625,7 @@ func TestProcessSingleResetFetchWhenAlreadyOnBranch(t *testing.T) {
 	runCmd(t, otherDir, "git", "push", "origin", "main")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, remoteTarget("origin", "main"), "soft", nil)
+	res := processSingleReset(context.Background(), repo, remoteTarget("origin", "main"), "soft", nil)
 
 	if !res.Success {
 		t.Fatalf("expected Success=true (should fetch then reset), got error=%q skipped=%v reason=%q",
@@ -828,7 +828,7 @@ func TestProcessSingleResetLocalHardNoRemote(t *testing.T) {
 	safeHash := strings.TrimSpace(string(runCmdOutput(t, repoDir, "git", "rev-parse", "safe")))
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, resetTarget{branch: "safe"}, "hard", nil)
+	res := processSingleReset(context.Background(), repo, resetTarget{branch: "safe"}, "hard", nil)
 
 	if !res.Success {
 		t.Fatalf("expected Success=true for local hard reset, got error=%q skipped=%v reason=%q", res.Error, res.Skipped, res.SkipReason)
@@ -859,7 +859,7 @@ func TestProcessSingleResetLocalFallbackToRemote(t *testing.T) {
 	runCmd(t, otherDir, "git", "push", "origin", "only-on-remote")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, resetTarget{branch: "only-on-remote", fallbackRemote: "origin"}, "hard", nil)
+	res := processSingleReset(context.Background(), repo, resetTarget{branch: "only-on-remote", fallbackRemote: "origin"}, "hard", nil)
 
 	if !res.Success {
 		t.Fatalf("expected Success=true via remote fallback, got error=%q skipped=%v reason=%q", res.Error, res.Skipped, res.SkipReason)
@@ -876,7 +876,7 @@ func TestProcessSingleResetLocalMissingEverywhere(t *testing.T) {
 	repoDir, _ := makeRepoWithRemote(t)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "test"}
-	res := processSingleReset(repo, resetTarget{branch: "ghost-branch", fallbackRemote: "origin"}, "hard", nil)
+	res := processSingleReset(context.Background(), repo, resetTarget{branch: "ghost-branch", fallbackRemote: "origin"}, "hard", nil)
 
 	if !res.Skipped {
 		t.Fatalf("expected skip when branch is absent locally and on remote, got success=%v error=%q", res.Success, res.Error)

--- a/internal/core/run.go
+++ b/internal/core/run.go
@@ -248,6 +248,7 @@ func reorderArgs(args []string) []string {
 				"-h": true, "--help": true,
 				"-iw": true, "--include-worktrees": true,
 				"-wl": true, "--worktree-list": true,
+				"-tr": true, "--track": true,
 			}
 			if !boolFlags[arg] && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 				i++
@@ -435,11 +436,57 @@ func Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	divergeSet := false
 	fs.Visit(func(f *flag.Flag) {
 		if f.Name == "remote" || f.Name == "r" {
 			cfg.RemoteExplicit = true
 		}
+		if f.Name == "diverge" || f.Name == "dv" {
+			divergeSet = true
+		}
 	})
+
+	modes := []struct {
+		name string
+		set  bool
+	}{
+		{"-c/--cmd", *runCommand != ""},
+		{"-sh/--shell", *runShell != ""},
+		{"-l/--list", *listBranches},
+		{"-dv/--diverge", divergeSet},
+		{"-tr/--track", *trackUpstream},
+		{"-rs/--reset-soft", *resetSoft != ""},
+		{"-rh/--reset-hard", *resetHard != ""},
+		{"-rb/--rebase", *rebaseBranch != ""},
+		{"-wl/--worktree-list", *wtList},
+		{"-wc/--worktree-create", *wtCreate != ""},
+		{"-wr/--worktree-remove", *wtRemove != ""},
+		{"-wo/--worktree-open", *wtOpen != ""},
+	}
+	var selected []string
+	for _, m := range modes {
+		if m.set {
+			selected = append(selected, m.name)
+		}
+	}
+	if len(selected) > 1 {
+		return fmt.Errorf("conflicting options: %s — use one operation at a time", strings.Join(selected, ", "))
+	}
+
+	for _, ref := range []struct{ kind, val string }{
+		{"remote", *remoteName},
+		{"branch", *resetSoft},
+		{"branch", *resetHard},
+		{"branch", *rebaseBranch},
+		{"branch", *wtCreate},
+		{"pattern", *wtRemove},
+		{"branch", *wtOpen},
+		{"branch", *diverge},
+	} {
+		if ref.val != "" && strings.HasPrefix(ref.val, "-") {
+			return fmt.Errorf("invalid %s %q: must not start with '-'", ref.kind, ref.val)
+		}
+	}
 
 	root, _ := os.Getwd()
 	root = resolveRoot(root)
@@ -456,13 +503,10 @@ func Run(ctx context.Context, args []string) error {
 		return listAllBranches(ctx, root, *workers, cfg)
 	}
 
-	divergeSet := false
-	fs.Visit(func(f *flag.Flag) {
-		if f.Name == "diverge" || f.Name == "dv" {
-			divergeSet = true
-		}
-	})
 	if divergeSet {
+		if fs.NArg() > 0 {
+			return fmt.Errorf("unexpected argument %q: -dv takes its branch inline, e.g. 'gb -dv main'", fs.Arg(0))
+		}
 		return checkDiverge(ctx, root, *diverge, *workers, cfg)
 	}
 

--- a/internal/core/run.go
+++ b/internal/core/run.go
@@ -488,6 +488,10 @@ func Run(ctx context.Context, args []string) error {
 		}
 	}
 
+	if fs.NArg() >= 1 && strings.HasPrefix(fs.Arg(0), "-") {
+		return fmt.Errorf("invalid argument %q: must not start with '-'", fs.Arg(0))
+	}
+
 	root, _ := os.Getwd()
 	root = resolveRoot(root)
 
@@ -500,6 +504,9 @@ func Run(ctx context.Context, args []string) error {
 	}
 
 	if *listBranches {
+		if fs.NArg() > 0 {
+			return fmt.Errorf("unexpected argument %q: -l takes no branch argument", fs.Arg(0))
+		}
 		return listAllBranches(ctx, root, *workers, cfg)
 	}
 
@@ -511,6 +518,9 @@ func Run(ctx context.Context, args []string) error {
 	}
 
 	if *trackUpstream {
+		if fs.NArg() > 0 {
+			return fmt.Errorf("unexpected argument %q: -tr takes no branch argument", fs.Arg(0))
+		}
 		return checkTrack(ctx, root, *workers, cfg)
 	}
 
@@ -538,6 +548,9 @@ func Run(ctx context.Context, args []string) error {
 	}
 
 	if *wtList {
+		if fs.NArg() > 0 {
+			return fmt.Errorf("unexpected argument %q: -wl takes no branch argument", fs.Arg(0))
+		}
 		return worktreeListAll(ctx, root, *workers, cfg)
 	}
 

--- a/internal/core/switch.go
+++ b/internal/core/switch.go
@@ -29,13 +29,13 @@ func switchBranches(ctx context.Context, root, target string, workers int, cfg *
 	}
 
 	progress := NewProgressState(repos, "Switching branches", cfg.PageSize)
-	stop := progress.start()
+	progress.StartInput()
 
-	results := runPool(ctx, repos, workers, func(_ context.Context, r RepoInfo) SwitchResult {
+	results := runPool(ctx, repos, workers, func(ctx context.Context, r RepoInfo) SwitchResult {
 		progress.UpdateStatus(r.RelPath, statusProcessing, "")
 
 		logFile, _ := logManager.CreateLogFile(r.RelPath)
-		res := processSingleRepo(r, target, cfg.Remote, logFile)
+		res := processSingleRepo(ctx, r, target, cfg.Remote, logFile)
 		if logFile != nil {
 			_ = logFile.Close()
 		}
@@ -63,16 +63,13 @@ func switchBranches(ctx context.Context, root, target string, workers int, cfg *
 		}
 	}
 
-	stop()
-
-	fmt.Println("\n" + StyleBold.Render("--- Summary ---"))
-	fmt.Printf("Switched %s repos to %s, %s skipped (branch in worktree), %s failed\n",
+	summary := StyleBold.Render("--- Summary ---") + "\n" + fmt.Sprintf("Switched %s repos to %s, %s skipped (branch in worktree), %s failed",
 		StyleSuccess.Render(fmt.Sprintf("%d", ok)),
 		target,
 		StyleSkipped.Render(fmt.Sprintf("%d", skip)),
 		StyleFailed.Render(fmt.Sprintf("%d", fail)))
 
-	if PromptViewLogs() {
+	if progress.FinishAndPromptViewLogs(summary) {
 		DisplaySwitchLogs(logManager, results)
 	} else {
 		fmt.Printf("\nLogs are available at: %s\n", logManager.GetTempDir())
@@ -107,7 +104,7 @@ func isBranchLockedInWorktree(repoPath, targetBranch string) bool {
 	return false
 }
 
-func processSingleRepo(repo RepoInfo, targetBranch, remote string, logFile *os.File) SwitchResult {
+func processSingleRepo(ctx context.Context, repo RepoInfo, targetBranch, remote string, logFile *os.File) SwitchResult {
 	log := func(format string, args ...any) {
 		if logFile != nil {
 			_, _ = fmt.Fprintf(logFile, format+"\n", args...)
@@ -130,7 +127,7 @@ func processSingleRepo(repo RepoInfo, targetBranch, remote string, logFile *os.F
 
 	if !branchExists {
 		log("Checking remote for branch...")
-		remoteCheck := exec.Command("git", "ls-remote", "--exit-code", "--heads", remote, targetBranch)
+		remoteCheck := exec.CommandContext(ctx, "git", "-c", "protocol.ext.allow=never", "ls-remote", "--exit-code", "--heads", remote, targetBranch)
 		remoteCheck.Dir = repo.Path
 		if remoteCheck.Run() == nil {
 			checkCmd := exec.Command("git", "rev-parse", "--is-shallow-repository")
@@ -138,14 +135,14 @@ func processSingleRepo(repo RepoInfo, targetBranch, remote string, logFile *os.F
 			out, err := checkCmd.Output()
 			isShallow := err == nil && strings.TrimSpace(string(out)) == "true"
 
-			args := []string{"fetch", remote}
+			args := []string{"-c", "protocol.ext.allow=never", "fetch", remote}
 			if isShallow {
 				args = append(args, "--depth=1")
 			}
 			args = append(args, targetBranch)
 
 			log("Executing: git %s", strings.Join(args, " "))
-			fetchCmd := exec.Command("git", args...)
+			fetchCmd := exec.CommandContext(ctx, "git", args...)
 			fetchCmd.Dir = repo.Path
 			if logFile != nil {
 				fetchCmd.Stdout = logFile
@@ -163,7 +160,7 @@ func processSingleRepo(repo RepoInfo, targetBranch, remote string, logFile *os.F
 	}
 
 	log("Executing: git switch %s", targetBranch)
-	switchCmd := exec.Command("git", "switch", targetBranch)
+	switchCmd := exec.CommandContext(ctx, "git", "switch", targetBranch)
 	switchCmd.Dir = repo.Path
 	if logFile != nil {
 		switchCmd.Stdout = logFile
@@ -176,7 +173,7 @@ func processSingleRepo(repo RepoInfo, targetBranch, remote string, logFile *os.F
 
 	log("Switch failed, trying to create tracking branch...")
 	log("Executing: git switch -c %s --track %s/%s", targetBranch, remote, targetBranch)
-	trackCmd := exec.Command("git", "switch", "-c", targetBranch, "--track", remote+"/"+targetBranch)
+	trackCmd := exec.CommandContext(ctx, "git", "switch", "-c", targetBranch, "--track", remote+"/"+targetBranch)
 	trackCmd.Dir = repo.Path
 	if logFile != nil {
 		trackCmd.Stdout = logFile

--- a/internal/core/track.go
+++ b/internal/core/track.go
@@ -15,13 +15,13 @@ type TrackResult struct {
 	Error    string
 }
 
-func processSingleTrack(repo RepoInfo) TrackResult {
+func processSingleTrack(ctx context.Context, repo RepoInfo) TrackResult {
 	branch, err := getBranch(repo.Path)
 	if err != nil {
 		return TrackResult{RelPath: repo.RelPath, Error: "failed to get branch: " + err.Error()}
 	}
 
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
 	cmd.Dir = repo.Path
 	out, err := cmd.Output()
 	if err != nil {
@@ -46,8 +46,8 @@ func checkTrack(ctx context.Context, root string, workers int, cfg *Config) erro
 		"Found %d repos (filtered from %d discovered), checking upstream tracking with %d workers...",
 		len(repos), total, min(workers, len(repos)))))
 
-	results := runPool(ctx, repos, workers, func(_ context.Context, r RepoInfo) TrackResult {
-		return processSingleTrack(r)
+	results := runPool(ctx, repos, workers, func(ctx context.Context, r RepoInfo) TrackResult {
+		return processSingleTrack(ctx, r)
 	})
 
 	sort.Slice(results, func(i, j int) bool { return results[i].RelPath < results[j].RelPath })
@@ -62,13 +62,14 @@ func checkTrack(ctx context.Context, root string, workers int, cfg *Config) erro
 		}
 	}
 
-	tracking, untracked := 0, 0
+	tracking, untracked, failed := 0, 0, 0
 	for _, r := range results {
 		pathCol := fmt.Sprintf("%-*s", maxPath, r.RelPath)
 		branchCol := fmt.Sprintf("%-*s", maxBranch, r.Branch)
 
 		if r.Error != "" {
 			fmt.Printf("%s  %s  → %s\n", pathCol, branchCol, StyleFailed.Render(r.Error))
+			failed++
 			continue
 		}
 
@@ -87,5 +88,9 @@ func checkTrack(ctx context.Context, root string, workers int, cfg *Config) erro
 		StyleSuccess.Render(fmt.Sprintf("%d", tracking)),
 		StyleSkipped.Render(fmt.Sprintf("%d", untracked)))
 
+	if failed > 0 {
+		fmt.Printf("  %s failed\n", StyleFailed.Render(fmt.Sprintf("%d", failed)))
+		return errReposFailed
+	}
 	return nil
 }

--- a/internal/core/track_test.go
+++ b/internal/core/track_test.go
@@ -1,6 +1,9 @@
 package core
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestProcessSingleTrackWithUpstream(t *testing.T) {
 	remoteDir := t.TempDir()
@@ -12,7 +15,7 @@ func TestProcessSingleTrackWithUpstream(t *testing.T) {
 	runCmd(t, repoDir, "git", "push", "-u", "origin", "main")
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleTrack(repo)
+	res := processSingleTrack(context.Background(), repo)
 
 	if res.Error != "" {
 		t.Fatalf("expected no error, got: %s", res.Error)
@@ -30,7 +33,7 @@ func TestProcessSingleTrackNoUpstream(t *testing.T) {
 	createGitRepo(t, repoDir)
 
 	repo := RepoInfo{Path: repoDir, RelPath: "repo"}
-	res := processSingleTrack(repo)
+	res := processSingleTrack(context.Background(), repo)
 
 	if res.Error != "" {
 		t.Fatalf("expected no error, got: %s", res.Error)

--- a/internal/core/worktree.go
+++ b/internal/core/worktree.go
@@ -67,7 +67,7 @@ func worktreeCreate(ctx context.Context, root, branch, base string, workers int,
 	}
 
 	progress := NewProgressState(repos, fmt.Sprintf("Creating worktree '%s'", branch), cfg.PageSize)
-	stop := progress.start()
+	progress.StartInput()
 
 	results := runPool(ctx, repos, workers, func(ctx context.Context, r RepoInfo) CommandResult {
 		progress.UpdateStatus(r.RelPath, statusProcessing, "")
@@ -138,16 +138,13 @@ func worktreeCreate(ctx context.Context, root, branch, base string, workers int,
 		}
 	}
 
-	stop()
-
-	fmt.Println("\n" + StyleBold.Render("--- Summary ---"))
-	fmt.Printf("Created worktrees for '%s': %s succeeded, %s skipped, %s failed\n",
+	summary := StyleBold.Render("--- Summary ---") + "\n" + fmt.Sprintf("Created worktrees for '%s': %s succeeded, %s skipped, %s failed",
 		branch,
 		StyleSuccess.Render(fmt.Sprintf("%d", success)),
 		StyleSkipped.Render(fmt.Sprintf("%d", skipped)),
 		StyleFailed.Render(fmt.Sprintf("%d", failed)))
 
-	if PromptViewLogs() {
+	if progress.FinishAndPromptViewLogs(summary) {
 		DisplayLogs(logManager, results)
 	} else {
 		fmt.Printf("\nLogs are available at: %s\n", logManager.GetTempDir())
@@ -174,7 +171,7 @@ func worktreeRemove(ctx context.Context, root, branch string, workers int, cfg *
 	}
 
 	progress := NewProgressState(repos, fmt.Sprintf("Removing worktree '%s'", branch), cfg.PageSize)
-	stop := progress.start()
+	progress.StartInput()
 
 	results := runPool(ctx, repos, workers, func(ctx context.Context, r RepoInfo) CommandResult {
 		progress.UpdateStatus(r.RelPath, statusProcessing, "")
@@ -204,16 +201,13 @@ func worktreeRemove(ctx context.Context, root, branch string, workers int, cfg *
 		}
 	}
 
-	stop()
-
-	fmt.Println("\n" + StyleBold.Render("--- Summary ---"))
-	fmt.Printf("Removed worktrees for '%s': %s succeeded, %s skipped, %s failed\n",
+	summary := StyleBold.Render("--- Summary ---") + "\n" + fmt.Sprintf("Removed worktrees for '%s': %s succeeded, %s skipped, %s failed",
 		branch,
 		StyleSuccess.Render(fmt.Sprintf("%d", success)),
 		StyleSkipped.Render(fmt.Sprintf("%d", skipped)),
 		StyleFailed.Render(fmt.Sprintf("%d", failed)))
 
-	if PromptViewLogs() {
+	if progress.FinishAndPromptViewLogs(summary) {
 		DisplayLogs(logManager, results)
 	} else {
 		fmt.Printf("\nLogs are available at: %s\n", logManager.GetTempDir())
@@ -256,8 +250,6 @@ func worktreeRemoveGlob(ctx context.Context, r RepoInfo, pattern string, out io.
 			continue
 		}
 		_, _ = fmt.Fprintf(out, "Removed worktree: %s\n", wtPath)
-		_ = os.Remove(filepath.Dir(wtPath))
-		_ = os.Remove(filepath.Dir(filepath.Dir(wtPath)))
 	}
 
 	if matched == 0 {
@@ -307,8 +299,6 @@ func worktreeRemoveExact(ctx context.Context, r RepoInfo, branch string, out io.
 		return CommandResult{RelPath: r.RelPath, Error: removeErr}
 	}
 	_, _ = fmt.Fprintf(out, "Removed worktree: %s\n", wtPath)
-	_ = os.Remove(filepath.Dir(wtPath))
-	_ = os.Remove(filepath.Dir(filepath.Dir(wtPath)))
 	progress.UpdateStatus(r.RelPath, statusCompleted, "")
 	return CommandResult{RelPath: r.RelPath}
 }
@@ -442,7 +432,12 @@ func copyFile(src, dst string) error {
 	}
 	defer func() { _ = in.Close() }()
 
-	out, err := os.Create(dst)
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix git command argument and exit-code handling, and keep repo paging working while the view-logs prompt is open.
