### PR TITLE
Pin GoReleaser to the dispatched tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+          GORELEASER_CURRENT_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}


### PR DESCRIPTION
`release --clean` resolved the version from the tags pointing at HEAD, version-sorted. Commit 59c10d4 carried both `v0.2.71-rc` and `v0.2.7`, so `0.2.71` won and run 30540124306 re-published the `v0.2.71-rc` release (every asset upload 422 `already_exists`) instead of creating `v0.2.7`.

Setting `GORELEASER_CURRENT_TAG` makes the dispatched tag (or the pushed ref) authoritative.